### PR TITLE
Swap out default Invidious instances

### DIFF
--- a/lib/main.dart
+++ b/lib/main.dart
@@ -47,7 +47,7 @@ Database settingDB;
 PackageInfo packageInfo;
 
 var brightness = ValueNotifier("dark");
-var invidiosAPI = ValueNotifier("https://invidio.us/");
+var invidiosAPI = ValueNotifier("https://invidious.snopyta.org/");
 var quality = ValueNotifier("best");
 
 var ignorePositionUpdate = ValueNotifier(false);
@@ -897,7 +897,7 @@ class MyHomePageState extends State<MyHomePage>
                               applicationVersion: packageInfo.version,
                               children: [
                                 Text(
-                                    "MusicPiped is an Material Designed inspired music player, using NewPipeExtractor and Invidio.us APIs"),
+                                    "MusicPiped is an Material Designed inspired music player, using NewPipeExtractor and Invidious APIs"),
                                 Text("Thank You"),
                                 InkWell(
                                   child: Container(

--- a/lib/searchScreen.dart
+++ b/lib/searchScreen.dart
@@ -417,7 +417,7 @@ class SearchScreenState extends State<SearchScreen> {
   }
 
   Future<dynamic> searchVid(searchquery) async {
-    String invidiosApi = "https://invidio.us/";
+    String invidiosApi = "https://invidious.snopyta.org/";
     String apiurl =
         invidiosApi + "api/v1/search?type=" + _type + "&q=" + searchquery;
     print(apiurl);
@@ -453,7 +453,7 @@ class SearchScreenState extends State<SearchScreen> {
   }
 
   Future<Map> fetchVid(id) async {
-    String invidiosApi = "https://invidio.us/";
+    String invidiosApi = "https://invidious.snopyta.org/";
     String apiurl = invidiosApi + "api/v1/videos/";
     String videoId = id;
     final response = await http.get(apiurl + videoId);


### PR DESCRIPTION
The invidio.us server longer runs so MusicPiped is broken at present. This change is simply a string replacement of invidio.us to invidious.snopyta.org. I'm not an Android developer so I don't have the tools set up to test it.