### PR TITLE
Fix Invidious API URL in settings and convert hard-coded URLs in search

### DIFF
--- a/lib/main.dart
+++ b/lib/main.dart
@@ -47,7 +47,7 @@ Database settingDB;
 PackageInfo packageInfo;
 
 var brightness = ValueNotifier("dark");
-var invidiosAPI = ValueNotifier("https://invidious.snopyta.org/");
+var invidiosAPI = ValueNotifier("https://invidious.xyz/");
 var quality = ValueNotifier("best");
 
 var ignorePositionUpdate = ValueNotifier(false);
@@ -135,10 +135,10 @@ Future<Database> initSettings() async {
   } else {
     brightness.value = await ob.getObject('brightness');
   }
-  if ((await ob.getObject('invidiousApi')) == null) {
-    ob.put(invidiosAPI.value, 'invidiousApi');
+  if ((await ob.getObject('invidiosAPI')) == null) {
+    ob.put(invidiosAPI.value, 'invidiosAPI');
   } else {
-    invidiosAPI.value = await ob.getObject("invidiousApi");
+    invidiosAPI.value = await ob.getObject("invidiosAPI");
   }
   if ((await ob.getObject('quality')) == null) {
     ob.put(quality.value, 'quality');
@@ -897,7 +897,7 @@ class MyHomePageState extends State<MyHomePage>
                               applicationVersion: packageInfo.version,
                               children: [
                                 Text(
-                                    "MusicPiped is an Material Designed inspired music player, using NewPipeExtractor and Invidious APIs"),
+                                    "MusicPiped is an Material Designed inspired music player, using NewPipeExtractor and Invidio.us APIs"),
                                 Text("Thank You"),
                                 InkWell(
                                   child: Container(

--- a/lib/searchScreen.dart
+++ b/lib/searchScreen.dart
@@ -417,9 +417,8 @@ class SearchScreenState extends State<SearchScreen> {
   }
 
   Future<dynamic> searchVid(searchquery) async {
-    String invidiosApi = "https://invidious.snopyta.org/";
     String apiurl =
-        invidiosApi + "api/v1/search?type=" + _type + "&q=" + searchquery;
+        main.MyHomePageState.InvidiosAPI + "search?type=" + _type + "&q=" + searchquery;
     print(apiurl);
 
     try {
@@ -453,8 +452,7 @@ class SearchScreenState extends State<SearchScreen> {
   }
 
   Future<Map> fetchVid(id) async {
-    String invidiosApi = "https://invidious.snopyta.org/";
-    String apiurl = invidiosApi + "api/v1/videos/";
+    String apiurl = main.MyHomePageState.InvidiosAPI + "videos/";
     String videoId = id;
     final response = await http.get(apiurl + videoId);
     print("received");


### PR DESCRIPTION
* Fix the Invidious API URL in settings, suggested by @Sbado in #131. Note that URL in settings must end with a / (may add code to sanitize input later)
* Change default API URL to "invidious.xyz" (defaults on first run and in case settings URL can not be read)
* Convert hard-coded URLs in searchScreen.dart to use URL in settings

Debug build tested working on my Galaxy S7 using "invidious.xyz" entered via the settings page. Hope it works for you.

P.S. This is my first ever pull request so maybe it's a little rough (the three commits when I tried to fix a spelling error in the short description). But practice makes perfect, right? ^_^