### PR TITLE
Skip 2.2.1 update

### DIFF
--- a/android/app/build.gradle
+++ b/android/app/build.gradle
@@ -77,7 +77,7 @@ flutter {
 }
 
 dependencies {
-    testImplementation 'junit:junit:4.13.1'
+    testImplementation 'junit:junit:4.13.2'
     androidTestImplementation 'com.android.support.test:runner:1.0.2'
     androidTestImplementation 'com.android.support.test.espresso:espresso-core:3.0.2'
     androidTestImplementation "com.android.support:support-annotations:25.3.1"

--- a/android/app/build.gradle
+++ b/android/app/build.gradle
@@ -77,7 +77,7 @@ flutter {
 }
 
 dependencies {
-    testImplementation 'junit:junit:4.13-beta-3'
+    testImplementation 'junit:junit:4.13.1'
     androidTestImplementation 'com.android.support.test:runner:1.0.2'
     androidTestImplementation 'com.android.support.test.espresso:espresso-core:3.0.2'
     androidTestImplementation "com.android.support:support-annotations:25.3.1"
@@ -85,7 +85,7 @@ dependencies {
     implementation 'com.danikula:videocache:2.7.1'
     implementation 'com.github.TeamNewPipe:NewPipeExtractor:v0.21.14'
     implementation 'com.squareup.okhttp3:okhttp:4.9.0'
-    implementation 'androidx.media:media:1.1.0-rc01'
+    implementation 'androidx.media:media:1.1.0'
     implementation 'com.google.code.findbugs:jsr305:3.0.2'
 
     coreLibraryDesugaring 'com.android.tools:desugar_jdk_libs:1.0.9'

--- a/android/app/build.gradle
+++ b/android/app/build.gradle
@@ -44,8 +44,8 @@ android {
         applicationId "deep.ryd.rydplayer"
         minSdkVersion 23
         targetSdkVersion 28
-        versionCode 64
-        versionName "2.2.0"
+        versionCode 66
+        versionName "2.2.2"
         testInstrumentationRunner "android.support.test.runner.AndroidJUnitRunner"
     }
     signingConfigs {
@@ -83,7 +83,7 @@ dependencies {
     androidTestImplementation "com.android.support:support-annotations:25.3.1"
 
     implementation 'com.danikula:videocache:2.7.1'
-    implementation 'com.github.TeamNewPipe:NewPipeExtractor:v0.21.13'
+    implementation 'com.github.TeamNewPipe:NewPipeExtractor:v0.21.14'
     implementation 'com.squareup.okhttp3:okhttp:4.9.0'
     implementation 'androidx.media:media:1.1.0-rc01'
     implementation 'com.google.code.findbugs:jsr305:3.0.2'

--- a/android/app/src/main/java/deep/ryd/NewpipeDownloader.java
+++ b/android/app/src/main/java/deep/ryd/NewpipeDownloader.java
@@ -44,7 +44,8 @@ import okhttp3.ResponseBody;
  */
 
 public class NewpipeDownloader extends org.schabi.newpipe.extractor.downloader.Downloader {
-    public static final String USER_AGENT = "Mozilla/5.0 (Windows NT 6.1; WOW64; rv:43.0) Gecko/20100101 Firefox/43.0";
+    // Firefox ESR
+    public static final String USER_AGENT = "Mozilla/5.0 (Windows NT 10.0; rv:91.0) Gecko/20100101 Firefox/91.0";
 
     private static NewpipeDownloader instance;
     private String mCookies;

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -11,7 +11,7 @@ description: A Materialistic Music Player.
 # In iOS, build-name is used as CFBundleShortVersionString while build-number used as CFBundleVersion.
 # Read more about iOS versioning at
 # https://developer.apple.com/library/archive/documentation/General/Reference/InfoPlistKeyReference/Articles/CoreFoundationKeys.html
-version: 2.2.0
+version: 2.2.2
 
 environment:
   sdk: ">=2.1.0 <3.0.0"


### PR DESCRIPTION
An attempt to let F-Droid to build and upload the latest release. Also bump NewPipe Extractor and some other libraries as well. If merged, tag the 2.2.2 release.